### PR TITLE
Add options to WebpackModules.find

### DIFF
--- a/v2/1Lib Discord Internals/plugin.js
+++ b/v2/1Lib Discord Internals/plugin.js
@@ -100,9 +100,12 @@ module.exports = (Plugin) => {
          * At first this function will look thruogh alreary loaded modules cache. If no one of loaded modules is matched - then this function tries to load all modules and match for them. Loading any module may have unexpected side effects, like changing current locale of moment.js, so in that case there will be a warning the console. If no module matches - function will return null. You sould always take such predicate to match something, gut your code should be ready to recieve null in case if Discord update something in codebase.
          * If module is ES6 module and hafe default property - only default would be considered, otherwise - full module object.
          * @param {modulePredicate} filter Predicate to match module
+         * @param {object} [options] Options object.
+         * @param {boolean} [options.cacheOnly=false] Set to true if you want to search only the cache for modules.
          * @return {*} First module that matched by filter or null if none is matched.
          */
-        const find = (filter) => {
+        const find = (filter, options = {}) => {
+            const {cacheOnly = false} = options;
             for (let i in req.c) {
                 if (req.c.hasOwnProperty(i)) {
                     let m = req.c[i].exports;
@@ -111,6 +114,10 @@ module.exports = (Plugin) => {
                     if (m && filter(m))
                         return m;
                 }
+            }
+            if (cacheOnly) {
+                console.warn('Cannot find loaded module in cache');
+                return null;
             }
             console.warn('Cannot find loaded module in cache. Loading all modules may have unexpected side effects');
             for (let i = 0; i < req.m.length; ++i) {
@@ -128,18 +135,20 @@ module.exports = (Plugin) => {
          * Look through all modules of internal Discord's Webpack and return first object that has all of following properties. You should be ready that in any moment, after Discord update, this function may start returning null (if no such object exists any more) or even some different object with the same properties. So you should provide all property names that you use, and often even some extra properties to make sure you'll get exactly what you want.
          * @see Read {@link find} documentation for more details how search works
          * @param {string[]} propNames Array of property names to look for
+         * @param {object} [options] Options object to pass to {@link find}.
          * @return {object} First module that matched by propNames or null if none is matched.
          */
-        const findByUniqueProperties = (propNames) => find(module => propNames.every(prop => module[prop] !== undefined));
+        const findByUniqueProperties = (propNames, options) => find(module => propNames.every(prop => module[prop] !== undefined), options);
 
         /**
          * Look through all modules of internal Discord's Webpack and return first object that has displayName property with following value. This is useful for searching React components by name. Take into account that not all components are exported as modules. Also there might be several components with same names
          * @see Use {@link ReactComponents} as another way to get react components
          * @see Read {@link find} documentation for more details how search works
          * @param {string} displayName Display name property value to look for
+         * @param {object} [options] Options object to pass to {@link find}.
          * @return {object} First module that matched by displayName or null if none is matched.
          */
-        const findByDisplayName = (displayName) => find(module => module.displayName === displayName);
+        const findByDisplayName = (displayName, options) => find(module => module.displayName === displayName, options);
 
         return {find, findByUniqueProperties, findByDisplayName};
 

--- a/v2/1Lib Discord Internals/plugin.js
+++ b/v2/1Lib Discord Internals/plugin.js
@@ -98,7 +98,7 @@ module.exports = (Plugin) => {
         /**
          * Look through all modules of internal Discord's Webpack and return first one that match filter predicate.
          * At first this function will look thruogh alreary loaded modules cache. If no one of loaded modules is matched - then this function tries to load all modules and match for them. Loading any module may have unexpected side effects, like changing current locale of moment.js, so in that case there will be a warning the console. If no module matches - function will return null. You sould always take such predicate to match something, gut your code should be ready to recieve null in case if Discord update something in codebase.
-         * If module is ES6 module and hafe default property - only default would be considered, otherwise - full module object.
+         * If module is ES6 module and has default property, consider default first, otherwise - full module object.
          * @param {modulePredicate} filter Predicate to match module
          * @param {object} [options] Options object.
          * @param {boolean} [options.cacheOnly=false] Set to true if you want to search only the cache for modules.
@@ -109,8 +109,8 @@ module.exports = (Plugin) => {
             for (let i in req.c) {
                 if (req.c.hasOwnProperty(i)) {
                     let m = req.c[i].exports;
-                    if (m && m.__esModule && m.default)
-                        m = m.default;
+                    if (m && m.__esModule && m.default && filter(m.default))
+                        return m.default;
                     if (m && filter(m))
                         return m;
                 }
@@ -122,8 +122,8 @@ module.exports = (Plugin) => {
             console.warn('Cannot find loaded module in cache. Loading all modules may have unexpected side effects');
             for (let i = 0; i < req.m.length; ++i) {
                 let m = req(i);
-                if (m && m.__esModule && m.default)
-                    m = m.default;
+                if (m && m.__esModule && m.default && filter(m.default))
+                    return m.default;
                 if (m && filter(m))
                     return m;
             }


### PR DESCRIPTION
This adds an option to limit the search for modules to only those in the cache. For some modules, we can be optimistic that they will already be cached unless a breaking change is made to an internal API and they no longer exist. In this case, it would be preferable to handle the situation gracefully instead of causing side effects that can only be resolved by reloading the client.

Also, It seems that there are some cases where it's necessary to monkey patch methods on a module object itself instead of those on its `default` property (`hasAnimatedAvatar`, [for example](https://github.com/noodlebox/betterdiscord-plugins/blob/35efecd90d96039dcf41e0a8fac50763e9b199b1/StaticAvatars.plugin.js#L31)). This change allows `find` to try the module object itself if its `default` property does not match. It should be backwards compatible with existing code, but I could put it behind another option if you think the old behavior might still be useful in some cases.