### PR TITLE
Fix detection of Tooltip component

### DIFF
--- a/v1/quoter.plugin.js
+++ b/v1/quoter.plugin.js
@@ -1131,7 +1131,7 @@
 	
 		        patchMessageRender() {
 		            ReactComponents.get('Message', Message => {
-		                const Tooltip = WebpackModules.findByDisplayName('Tooltip');
+		                const Tooltip = WebpackModules.find(m => m && m.prototype && m.prototype.showDelayed);
 		                const cancel = Renderer.patchRender(Message, [
 		                    {
 		                        selector: {

--- a/v2/Quoter/plugin.js
+++ b/v2/Quoter/plugin.js
@@ -371,7 +371,7 @@ module.exports = (Plugin, BD, Vendor, v1) => {
 
         patchMessageRender() {
             ReactComponents.get('Message', Message => {
-                const Tooltip = WebpackModules.findByDisplayName('Tooltip');
+                const Tooltip = WebpackModules.find(m => m && m.prototype && m.prototype.showDelayed);
                 const cancel = Renderer.patchRender(Message, [
                     {
                         selector: {


### PR DESCRIPTION
Tooltip no longer has a display name. This finds it by methods on its prototype and should fix #7 for now.