### PR TITLE
fix sending spotify embed

### DIFF
--- a/v1/quoter.plugin.js
+++ b/v1/quoter.plugin.js
@@ -707,7 +707,7 @@
 				"authors": [
 					"Samogot"
 				],
-				"version": "3.8",
+				"version": "3.9",
 				"description": "Add citation using embeds",
 				"repository": "https://github.com/samogot/betterdiscord-plugins.git",
 				"homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/Quoter",

--- a/v1/quoter.plugin.js
+++ b/v1/quoter.plugin.js
@@ -966,7 +966,12 @@
 	
 		        patchSendMessageForSplitAndPassEmbeds() {
 		            const cancel = monkeyPatch(MessageActions, 'sendMessage', {
-		                instead: ({methodArguments: [channelId, message], originalMethod, thisObject}) => {
+		                instead: ({methodArguments, originalMethod, thisObject}) => {
+							if (!this.quotes.length) {
+								const sendOriginal = originalMethod.bind(thisObject);
+								return sendOriginal(...methodArguments);
+							}
+							const [channelId, message] = methodArguments;
 		                    const sendMessageDirrect = originalMethod.bind(thisObject, channelId);
 		                    const currentChannel = QuoterPlugin.getCurrentChannel();
 		                    const serverIDs = this.getSetting('noEmbedsServers').split(/\D+/);

--- a/v2/Quoter/README.md
+++ b/v2/Quoter/README.md
@@ -47,6 +47,9 @@ There is [support server](https://discord.gg/MC5dJdE) for all my plugins includi
 
 ## Changelog
 
+### 3.9
+- Fix collision with spotify integration
+
 ### 3.8
 - Fix selectors and url placement after discord update. Thanks to Zerebos.
 

--- a/v2/Quoter/config.json
+++ b/v2/Quoter/config.json
@@ -4,7 +4,7 @@
     "authors": [
       "Samogot"
     ],
-    "version": "3.8",
+    "version": "3.9",
     "description": "Add citation using embeds",
     "repository": "https://github.com/samogot/betterdiscord-plugins.git",
     "homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/Quoter",

--- a/v2/Quoter/plugin.js
+++ b/v2/Quoter/plugin.js
@@ -199,7 +199,12 @@ module.exports = (Plugin, BD, Vendor, v1) => {
 
         patchSendMessageForSplitAndPassEmbeds() {
             const cancel = monkeyPatch(MessageActions, 'sendMessage', {
-                instead: ({methodArguments: [channelId, message], originalMethod, thisObject}) => {
+                instead: ({methodArguments, originalMethod, thisObject}) => {
+					if (!this.quotes.length) {
+						const sendOriginal = originalMethod.bind(thisObject);
+						return sendOriginal(...methodArguments);
+					}
+					const [channelId, message] = methodArguments;
                     const sendMessageDirrect = originalMethod.bind(thisObject, channelId);
                     const currentChannel = QuoterPlugin.getCurrentChannel();
                     const serverIDs = this.getSetting('noEmbedsServers').split(/\D+/);


### PR DESCRIPTION
This is a quick fix for being able to send the spotify embed. It seems with this spotify integration update `sendMessage` will now receive 4 arguments instead of the normal 2 in order to handle sending the unique embed. This PR checks for the existence of quotes and, barring any, calls the original function with the original arguments. This would fix #21 