### PR TITLE
Hotfix for latest context menu changes

### DIFF
--- a/v1/quoter.plugin.js
+++ b/v1/quoter.plugin.js
@@ -707,7 +707,7 @@
 				"authors": [
 					"Samogot"
 				],
-				"version": "3.9",
+				"version": "3.9.1",
 				"description": "Add citation using embeds",
 				"repository": "https://github.com/samogot/betterdiscord-plugins.git",
 				"homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/Quoter",
@@ -807,7 +807,7 @@
 		        MessageParser = WebpackModules.findByUniqueProperties(['createMessage', 'parse', 'unparse']);
 		        HistoryUtils = WebpackModules.findByUniqueProperties(['transitionTo', 'replaceWith', 'getHistory']);
 		        PermissionUtils = WebpackModules.findByUniqueProperties(['getChannelPermissions', 'can']);
-		        ContextMenuActions = WebpackModules.find(Filters.byCode(/CONTEXT_MENU_CLOSE/, c => c.close));
+		        ContextMenuActions = WebpackModules.findByUniqueProperties(['closeContextMenu']);
 	
 		        ModalsStack = WebpackModules.findByUniqueProperties(['push', 'update', 'pop', 'popWithKey']);
 		        ContextMenuItemsGroup = WebpackModules.find(Filters.byCode(/itemGroup/));
@@ -967,10 +967,12 @@
 		        patchSendMessageForSplitAndPassEmbeds() {
 		            const cancel = monkeyPatch(MessageActions, 'sendMessage', {
 		                instead: ({methodArguments, originalMethod, thisObject}) => {
+							
 							if (!this.quotes.length) {
 								const sendOriginal = originalMethod.bind(thisObject);
 								return sendOriginal(...methodArguments);
 							}
+							
 							const [channelId, message] = methodArguments;
 		                    const sendMessageDirrect = originalMethod.bind(thisObject, channelId);
 		                    const currentChannel = QuoterPlugin.getCurrentChannel();
@@ -1227,7 +1229,7 @@
 		        onQuoteMessageClick(channel, message, e) {
 		            e.preventDefault();
 		            e.stopPropagation();
-		            ContextMenuActions.close();
+		            ContextMenuActions.closeContextMenu();
 		            const {channelTextAreaForm, oldText} = this.tryClearQuotes();
 		            const citeFull = this.getSetting('citeFull');
 	

--- a/v2/Quoter/README.md
+++ b/v2/Quoter/README.md
@@ -47,6 +47,9 @@ There is [support server](https://discord.gg/MC5dJdE) for all my plugins includi
 
 ## Changelog
 
+### 3.9.1
+- Hotfix for latest context menu changes
+
 ### 3.9
 - Fix collision with spotify integration
 

--- a/v2/Quoter/config.json
+++ b/v2/Quoter/config.json
@@ -4,7 +4,7 @@
     "authors": [
       "Samogot"
     ],
-    "version": "3.9",
+    "version": "3.9.1",
     "description": "Add citation using embeds",
     "repository": "https://github.com/samogot/betterdiscord-plugins.git",
     "homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/Quoter",

--- a/v2/Quoter/plugin.js
+++ b/v2/Quoter/plugin.js
@@ -40,7 +40,7 @@ module.exports = (Plugin, BD, Vendor, v1) => {
         MessageParser = WebpackModules.findByUniqueProperties(['createMessage', 'parse', 'unparse']);
         HistoryUtils = WebpackModules.findByUniqueProperties(['transitionTo', 'replaceWith', 'getHistory']);
         PermissionUtils = WebpackModules.findByUniqueProperties(['getChannelPermissions', 'can']);
-        ContextMenuActions = WebpackModules.find(Filters.byCode(/CONTEXT_MENU_CLOSE/, c => c.close));
+        ContextMenuActions = WebpackModules.findByUniqueProperties(['closeContextMenu']);
 
         ModalsStack = WebpackModules.findByUniqueProperties(['push', 'update', 'pop', 'popWithKey']);
         ContextMenuItemsGroup = WebpackModules.find(Filters.byCode(/itemGroup/));
@@ -460,7 +460,7 @@ module.exports = (Plugin, BD, Vendor, v1) => {
         onQuoteMessageClick(channel, message, e) {
             e.preventDefault();
             e.stopPropagation();
-            ContextMenuActions.close();
+            ContextMenuActions.closeContextMenu();
             const {channelTextAreaForm, oldText} = this.tryClearQuotes();
             const citeFull = this.getSetting('citeFull');
 


### PR DESCRIPTION
This grabs the new `ContextMenuActions` module and updates the corresponding functions. This eliminates the problem people were describing in the server "cannot access property `close` of `null`" whenever trying to quote.

Also has a minor version bump.