### PR TITLE
Quoter v3.10 and LibDI v1.10

### DIFF
--- a/v1/1lib_discord_internals.plugin.js
+++ b/v1/1lib_discord_internals.plugin.js
@@ -454,7 +454,7 @@
 				"authors": [
 					"Samogot"
 				],
-				"version": "1.9",
+				"version": "1.10",
 				"description": "Discord Internals lib",
 				"repository": "https://github.com/samogot/betterdiscord-plugins.git",
 				"homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/1LibDiscordInternals",
@@ -805,8 +805,8 @@
 		        const req = typeof(webpackJsonp) === "function" ? webpackJsonp([], {
 		            '__extra_id__': (module, exports, req) => exports.default = req
 		        }, ['__extra_id__']).default : webpackJsonp.push([[], {
-					'__extra_id__': (module, exports, req) => module.exports = req
-				}, [['__extra_id__']]]);
+		            '__extra_id__': (module, exports, req) => module.exports = req
+		        }, [['__extra_id__']]]);
 		        delete req.m['__extra_id__'];
 		        delete req.c['__extra_id__'];
 	
@@ -970,7 +970,7 @@
 		            function getDisplayName(owner) {
 		                const type = owner.type;
 		                const constructor = owner.stateNode && owner.stateNode.constructor;
-		                return type && type.displayName || constructor && constructor.displayName || null;
+		                return type && type.displayName || constructor && (constructor.displayName || constructor.name) || null;
 		            }
 	
 		            function classFilter(owner) {
@@ -980,7 +980,7 @@
 	
 		            let curr = getInternalInstance(e);
 		            while (curr) {
-		                if (classFilter(curr)) {
+		                if (classFilter(curr) && !(curr instanceof HTMLElement)) {
 		                    return curr.stateNode;
 		                }
 		                curr = curr.return;
@@ -1046,7 +1046,7 @@
 		            }
 		        }
 	
-		        const reactRootInternalInstance = () => getInternalInstance(document.getElementById('app-mount').firstElementChild);
+		        const reactRootInternalInstance = () => document.getElementById("app-mount")._reactRootContainer._internalRoot.current;
 	
 		        /**
 		         * Generator for recursive traversal of rendered react component tree. Only component instances are returned.
@@ -1477,6 +1477,11 @@
 		                put(methodArguments[0]);
 		            }
 		        });
+	
+		        React.Component.prototype.UNSAFE_componentWillMount = function() {
+		            put(this.constructor);
+		        };
+	
 		        for (let component of Renderer.recursiveComponents()) {
 		            put(component.constructor);
 		        }

--- a/v1/quoter.plugin.js
+++ b/v1/quoter.plugin.js
@@ -707,7 +707,7 @@
 				"authors": [
 					"Samogot"
 				],
-				"version": "3.9.1",
+				"version": "3.10",
 				"description": "Add citation using embeds",
 				"repository": "https://github.com/samogot/betterdiscord-plugins.git",
 				"homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/Quoter",
@@ -718,8 +718,8 @@
 					"id": "embeds",
 					"type": "bool",
 					"text": "Use embeds for quoting",
-					"description": "Use embeds if possible and fallback to markdown-formated quotes otherwise. Uncheck if you want to always use fallback mode",
-					"value": true
+					"description": "Use embeds if possible and fallback to markdown-formated quotes otherwise. Markdown-formated (fallback) mode is text-only and is considered more safe, so it is default. Quoter don't use bot api to post embeds, but not everybody knows it, so some people might think that you are selfbot. It is recommended to not use embed mode in converstion with Discord stuff. Also orthodox admins of some servers may threat to ban you because of some rumors about selfbots. So USE AT YOUR OWN RISK! :)",
+					"value": false
 				},
 				{
 					"id": "noEmbedsServers",
@@ -770,7 +770,7 @@
 		    const {Api, Storage} = BD;
 		    let {$} = Vendor;
 	
-		    const minDIVersion = '1.6';
+		    const minDIVersion = '1.10';
 		    if (!window.DiscordInternals || !window.DiscordInternals.version ||
 		        window.DiscordInternals.versionCompare(window.DiscordInternals.version, minDIVersion) < 0) {
 		        const message = `Lib Discord Internals v${minDIVersion} or higher not found! Please install or upgrade that utility plugin. See install instructions here https://goo.gl/kQ7UMV`;
@@ -791,7 +791,10 @@
 		    const {monkeyPatch, WebpackModules, ReactComponents, getOwnerInstance, React, Renderer, Filters} = window.DiscordInternals;
 	
 		    // Deffer module loading
-		    let moment, Constants, GuildsStore, UsersStore, MembersStore, UserSettingsStore, MessageActions, MessageQueue, MessageParser, HistoryUtils, PermissionUtils, ContextMenuActions, ModalsStack, ContextMenuItemsGroup, ContextMenuItem, ExternalLink, ConfirmModal;
+		    let moment, Constants, GuildsStore, UsersStore, MembersStore, UserSettingsStore, MessageActions, MessageQueue,
+		        MessageParser, HistoryUtils, PermissionUtils, ContextMenuActions, ModalsStack, ContextMenuItemsGroup,
+		        ContextMenuItem, ExternalLink, ConfirmModal;
+	
 		    function loadAllModules() {
 		        moment = WebpackModules.findByUniqueProperties(['parseZone']);
 	
@@ -822,7 +825,7 @@
 		        // TooltipWrapper.displayName = 'TooltipWrapper';
 		    }
 	
-		    // ReactComponents.setName('Message', Filters.byPrototypeFields(['renderOptionPopout', 'renderUserPopout', 'handleMessageContextMenu']));
+		    ReactComponents.setName('Message', Filters.byPrototypeFields(['renderUsername']));
 		    // ReactComponents.setName('ChannelTextAreaForm', Filters.byPrototypeFields(['handleTextareaChange', 'render']));
 		    // ReactComponents.setName('OptionPopout', Filters.byPrototypeFields(['handleCopyId', 'handleEdit', 'handleRetry', 'handleDelete', 'handleReactions', '', '', '', '']));
 		    ReactComponents.setName('Embed', Filters.byPrototypeFields(['isMaskedLinkTrusted', 'renderProvider', 'renderAuthor', 'renderFooter', 'renderTitle', 'renderDescription', 'renderFields', 'renderImage', 'renderVideo', 'renderGIFV', 'hasProvider', 'renderSpotify']));
@@ -967,11 +970,11 @@
 		        patchSendMessageForSplitAndPassEmbeds() {
 		            const cancel = monkeyPatch(MessageActions, 'sendMessage', {
 		                instead: ({methodArguments, originalMethod, thisObject}) => {
-							if (!this.quotes.length) {
-								const sendOriginal = originalMethod.bind(thisObject);
-								return sendOriginal(...methodArguments);
-							}
-							const [channelId, message] = methodArguments;
+		                    if (!this.quotes.length) {
+		                        const sendOriginal = originalMethod.bind(thisObject);
+		                        return sendOriginal(...methodArguments);
+		                    }
+		                    const [channelId, message] = methodArguments;
 		                    const sendMessageDirrect = originalMethod.bind(thisObject, channelId);
 		                    const currentChannel = QuoterPlugin.getCurrentChannel();
 		                    const serverIDs = this.getSetting('noEmbedsServers').split(/\D+/);
@@ -1085,7 +1088,7 @@
 		                    id: quote.message.author.id,
 		                    name: quote.message.nick || quote.message.author.username,
 		                    icon_url: quote.message.author.avatar_url || new URL(quote.message.author.getAvatarURL(), location.href).href,
-							url: `${BASE_JUMP_URL}?guild_id=${quote.channel.guild_id || '@me'}&channel_id=${quote.channel.id}&message_id=${quote.message.id}&author_id=${quote.message.author.id}`
+		                    url: `${BASE_JUMP_URL}?guild_id=${quote.channel.guild_id || '@me'}&channel_id=${quote.channel.id}&message_id=${quote.message.id}&author_id=${quote.message.author.id}`
 		                },
 		                footer: {},
 		                timestamp: quote.message.timestamp.toISOString(),
@@ -1149,9 +1152,9 @@
 		                    let ids;
 		                    if (thisObject.props.href && (ids = QuoterPlugin.getIdsFromLink(thisObject.props.href))) {
 		                        thisObject.props.onClick = e => {
-									HistoryUtils.transitionTo(Constants.Routes.MESSAGE(ids.guild_id, ids.channel_id, ids.message_id));
-									e.preventDefault();
-								}
+		                            HistoryUtils.transitionTo(Constants.Routes.MESSAGE(ids.guild_id, ids.channel_id, ids.message_id));
+		                            e.preventDefault();
+		                        }
 		                    }
 		                }
 		            });

--- a/v2/1Lib Discord Internals/README.md
+++ b/v2/1Lib Discord Internals/README.md
@@ -18,6 +18,11 @@ There is [support server](https://discord.gg/MC5dJdE) for all my plugins includi
 
 ## Changelog
 
+### 1.10
+- Fix reactRootInternalInstance.
+- Use react private lifecycle method to bypass closuring createElement method. This should fix race condition of failing to get some components like `Message`.
+- Thanks to Zerebos for this changes.
+
 ### 1.9
 - Fix WebpackModules to support Webpack 4. Thanks to Zerebos for this change.
 

--- a/v2/1Lib Discord Internals/config.json
+++ b/v2/1Lib Discord Internals/config.json
@@ -4,7 +4,7 @@
     "authors": [
       "Samogot"
     ],
-    "version": "1.9",
+    "version": "1.10",
     "description": "Discord Internals lib",
     "repository": "https://github.com/samogot/betterdiscord-plugins.git",
     "homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/1LibDiscordInternals",

--- a/v2/1Lib Discord Internals/plugin.js
+++ b/v2/1Lib Discord Internals/plugin.js
@@ -94,8 +94,8 @@ module.exports = (Plugin) => {
         const req = typeof(webpackJsonp) === "function" ? webpackJsonp([], {
             '__extra_id__': (module, exports, req) => exports.default = req
         }, ['__extra_id__']).default : webpackJsonp.push([[], {
-			'__extra_id__': (module, exports, req) => module.exports = req
-		}, [['__extra_id__']]]);
+            '__extra_id__': (module, exports, req) => module.exports = req
+        }, [['__extra_id__']]]);
         delete req.m['__extra_id__'];
         delete req.c['__extra_id__'];
 
@@ -259,7 +259,7 @@ module.exports = (Plugin) => {
             function getDisplayName(owner) {
                 const type = owner.type;
                 const constructor = owner.stateNode && owner.stateNode.constructor;
-                return type && type.displayName || constructor && constructor.displayName || null;
+                return type && type.displayName || constructor && (constructor.displayName || constructor.name) || null;
             }
 
             function classFilter(owner) {
@@ -269,7 +269,7 @@ module.exports = (Plugin) => {
 
             let curr = getInternalInstance(e);
             while (curr) {
-                if (classFilter(curr)) {
+                if (classFilter(curr) && !(curr instanceof HTMLElement)) {
                     return curr.stateNode;
                 }
                 curr = curr.return;
@@ -335,7 +335,7 @@ module.exports = (Plugin) => {
             }
         }
 
-        const reactRootInternalInstance = () => getInternalInstance(document.getElementById('app-mount').firstElementChild);
+        const reactRootInternalInstance = () => document.getElementById("app-mount")._reactRootContainer._internalRoot.current;
 
         /**
          * Generator for recursive traversal of rendered react component tree. Only component instances are returned.
@@ -766,6 +766,11 @@ module.exports = (Plugin) => {
                 put(methodArguments[0]);
             }
         });
+
+        React.Component.prototype.UNSAFE_componentWillMount = function() {
+            put(this.constructor);
+        };
+
         for (let component of Renderer.recursiveComponents()) {
             put(component.constructor);
         }

--- a/v2/Quoter/README.md
+++ b/v2/Quoter/README.md
@@ -47,6 +47,10 @@ There is [support server](https://discord.gg/MC5dJdE) for all my plugins includi
 
 ## Changelog
 
+### 3.10
+- Fix partial quoting. Message component don't have display name any more, so use setName instead (and new version of lib)
+- Change default value of use embeds settings. Added disclaimer about selfbots, so admins of better discord server (and plugins repo) would be happy
+
 ### 3.9.1
 - Hotfix for latest context menu changes
 

--- a/v2/Quoter/config.json
+++ b/v2/Quoter/config.json
@@ -4,7 +4,7 @@
     "authors": [
       "Samogot"
     ],
-    "version": "3.9.1",
+    "version": "3.10",
     "description": "Add citation using embeds",
     "repository": "https://github.com/samogot/betterdiscord-plugins.git",
     "homepage": "https://github.com/samogot/betterdiscord-plugins/tree/master/v2/Quoter",
@@ -15,8 +15,8 @@
       "id": "embeds",
       "type": "bool",
       "text": "Use embeds for quoting",
-      "description": "Use embeds if possible and fallback to markdown-formated quotes otherwise. Uncheck if you want to always use fallback mode",
-      "value": true
+      "description": "Use embeds if possible and fallback to markdown-formated quotes otherwise. Markdown-formated (fallback) mode is text-only and is considered more safe, so it is default. Quoter don't use bot api to post embeds, but not everybody knows it, so some people might think that you are selfbot. It is recommended to not use embed mode in converstion with Discord stuff. Also orthodox admins of some servers may threat to ban you because of some rumors about selfbots. So USE AT YOUR OWN RISK! :)",
+      "value": false
     },
     {
       "id": "noEmbedsServers",

--- a/v2/Quoter/plugin.js
+++ b/v2/Quoter/plugin.js
@@ -3,7 +3,7 @@ module.exports = (Plugin, BD, Vendor, v1) => {
     const {Api, Storage} = BD;
     let {$} = Vendor;
 
-    const minDIVersion = '1.6';
+    const minDIVersion = '1.10';
     if (!window.DiscordInternals || !window.DiscordInternals.version ||
         window.DiscordInternals.versionCompare(window.DiscordInternals.version, minDIVersion) < 0) {
         const message = `Lib Discord Internals v${minDIVersion} or higher not found! Please install or upgrade that utility plugin. See install instructions here https://goo.gl/kQ7UMV`;
@@ -24,7 +24,10 @@ module.exports = (Plugin, BD, Vendor, v1) => {
     const {monkeyPatch, WebpackModules, ReactComponents, getOwnerInstance, React, Renderer, Filters} = window.DiscordInternals;
 
     // Deffer module loading
-    let moment, Constants, GuildsStore, UsersStore, MembersStore, UserSettingsStore, MessageActions, MessageQueue, MessageParser, HistoryUtils, PermissionUtils, ContextMenuActions, ModalsStack, ContextMenuItemsGroup, ContextMenuItem, ExternalLink, ConfirmModal;
+    let moment, Constants, GuildsStore, UsersStore, MembersStore, UserSettingsStore, MessageActions, MessageQueue,
+        MessageParser, HistoryUtils, PermissionUtils, ContextMenuActions, ModalsStack, ContextMenuItemsGroup,
+        ContextMenuItem, ExternalLink, ConfirmModal;
+
     function loadAllModules() {
         moment = WebpackModules.findByUniqueProperties(['parseZone']);
 
@@ -55,7 +58,7 @@ module.exports = (Plugin, BD, Vendor, v1) => {
         // TooltipWrapper.displayName = 'TooltipWrapper';
     }
 
-    // ReactComponents.setName('Message', Filters.byPrototypeFields(['renderOptionPopout', 'renderUserPopout', 'handleMessageContextMenu']));
+    ReactComponents.setName('Message', Filters.byPrototypeFields(['renderUsername']));
     // ReactComponents.setName('ChannelTextAreaForm', Filters.byPrototypeFields(['handleTextareaChange', 'render']));
     // ReactComponents.setName('OptionPopout', Filters.byPrototypeFields(['handleCopyId', 'handleEdit', 'handleRetry', 'handleDelete', 'handleReactions', '', '', '', '']));
     ReactComponents.setName('Embed', Filters.byPrototypeFields(['isMaskedLinkTrusted', 'renderProvider', 'renderAuthor', 'renderFooter', 'renderTitle', 'renderDescription', 'renderFields', 'renderImage', 'renderVideo', 'renderGIFV', 'hasProvider', 'renderSpotify']));
@@ -200,11 +203,11 @@ module.exports = (Plugin, BD, Vendor, v1) => {
         patchSendMessageForSplitAndPassEmbeds() {
             const cancel = monkeyPatch(MessageActions, 'sendMessage', {
                 instead: ({methodArguments, originalMethod, thisObject}) => {
-					if (!this.quotes.length) {
-						const sendOriginal = originalMethod.bind(thisObject);
-						return sendOriginal(...methodArguments);
-					}
-					const [channelId, message] = methodArguments;
+                    if (!this.quotes.length) {
+                        const sendOriginal = originalMethod.bind(thisObject);
+                        return sendOriginal(...methodArguments);
+                    }
+                    const [channelId, message] = methodArguments;
                     const sendMessageDirrect = originalMethod.bind(thisObject, channelId);
                     const currentChannel = QuoterPlugin.getCurrentChannel();
                     const serverIDs = this.getSetting('noEmbedsServers').split(/\D+/);
@@ -318,7 +321,7 @@ module.exports = (Plugin, BD, Vendor, v1) => {
                     id: quote.message.author.id,
                     name: quote.message.nick || quote.message.author.username,
                     icon_url: quote.message.author.avatar_url || new URL(quote.message.author.getAvatarURL(), location.href).href,
-					url: `${BASE_JUMP_URL}?guild_id=${quote.channel.guild_id || '@me'}&channel_id=${quote.channel.id}&message_id=${quote.message.id}&author_id=${quote.message.author.id}`
+                    url: `${BASE_JUMP_URL}?guild_id=${quote.channel.guild_id || '@me'}&channel_id=${quote.channel.id}&message_id=${quote.message.id}&author_id=${quote.message.author.id}`
                 },
                 footer: {},
                 timestamp: quote.message.timestamp.toISOString(),
@@ -382,9 +385,9 @@ module.exports = (Plugin, BD, Vendor, v1) => {
                     let ids;
                     if (thisObject.props.href && (ids = QuoterPlugin.getIdsFromLink(thisObject.props.href))) {
                         thisObject.props.onClick = e => {
-							HistoryUtils.transitionTo(Constants.Routes.MESSAGE(ids.guild_id, ids.channel_id, ids.message_id));
-							e.preventDefault();
-						}
+                            HistoryUtils.transitionTo(Constants.Routes.MESSAGE(ids.guild_id, ids.channel_id, ids.message_id));
+                            e.preventDefault();
+                        }
                     }
                 }
             });


### PR DESCRIPTION
Quoter v3.10:
- Fix partial quoting. Message component don't have display name any more, so use setName instead (and new version of lib)
- Change default value of use embeds settings. Added disclaimer about selfbots, so admins of better discord server (and plugins repo) would be happy

LibDI v1.10:
- Fix reactRootInternalInstance.
- Add scanning of rendered components on each chanel switch, so it is more likely to get closured components like `Message`.
- Thanks to Zerebos for this changes.