### PR TITLE
Fix version and versionCompare

### DIFF
--- a/v2/1Lib Discord Internals/plugin.js
+++ b/v2/1Lib Discord Internals/plugin.js
@@ -830,7 +830,7 @@ module.exports = (Plugin) => {
     class LibPlugin extends Plugin {
         constructor(props) {
             super(props);
-            window.DiscordInternals.version = props.version;
+            window.DiscordInternals.version = require("./config.json").info.version;
         }
 
         onStart() {


### PR DESCRIPTION
This pull request fixes versions. Before: `window.DiscordInternals.version = undefined`. Now, the version is taken from config.json